### PR TITLE
Make SequentialWorkQueue easier to use in complex asynchronous code execution scenarios

### DIFF
--- a/packages/patapata_core/lib/src/provider_model.dart
+++ b/packages/patapata_core/lib/src/provider_model.dart
@@ -518,6 +518,9 @@ abstract class ProviderModel<T> with ChangeNotifier {
   /// with the same [lockKey].
   /// Every [ProviderModel] has a default [ProviderLockKey] that this function will default to
   /// if [lockKey] is not set.
+  ///
+  /// For details on what [waitForMicrotasks], [waitForTimers], and [waitForPeriodicTimers] do,
+  /// see [SequentialWorkQueue.add].
   @nonVirtual
   Future<bool> lock(
     ProviderModelProcess process, {
@@ -525,6 +528,9 @@ abstract class ProviderModel<T> with ChangeNotifier {
     bool override = false,
     bool overridable = false,
     FutureOr<void> Function()? onOverride,
+    bool waitForMicrotasks = true,
+    bool waitForTimers = false,
+    bool waitForPeriodicTimers = false,
   }) async {
     assert(!_disposed, 'ProviderModel was already disposed.');
     assert(
@@ -550,7 +556,7 @@ abstract class ProviderModel<T> with ChangeNotifier {
 
             return tBatch.valid && !disposed;
           },
-          () async {
+          onCancel: () async {
             if (onOverride != null) {
               tBatch._disable();
               await onOverride();
@@ -564,6 +570,9 @@ abstract class ProviderModel<T> with ChangeNotifier {
 
             return false;
           },
+          waitForMicrotasks: waitForMicrotasks,
+          waitForTimers: waitForTimers,
+          waitForPeriodicTimers: waitForPeriodicTimers,
         ) ==
         true;
   }

--- a/packages/patapata_core/lib/src/sequential_work_queue.dart
+++ b/packages/patapata_core/lib/src/sequential_work_queue.dart
@@ -38,14 +38,13 @@ class SequentialWorkQueue {
   /// this function will error. However future [work] will
   /// continue to be processed correctly.
   ///
-  /// [work] is considered complete when the function itself returns, when
-  /// all [Future]s returned by [work] have completed, and if any asynchronous work
-  /// scheduled with [Future.microtask], [Future] or [Timer] inside [work] has completed.
-  /// Similar to how a main function is considered complete when all asynchronous work
+  /// [work] is considered complete when the function itself returns, if the returned value
+  /// is a [Future], when that [Future] completes, if [waitForMicrotasks] is true, when all
+  /// scheduled microtasks with [Future.microtask], [scheduleMicrotask], [Future], etc complete,
+  /// if [waitForTimers] is true, any [Timer] inside [work] has completed,
+  /// and finally if [waitForPeriodicTimers] is true, any [Timer.periodic] inside [work] has completed.
+  /// Similar to how a main function is considered complete when all asynchronous work.
   /// scheduled within it has completed.
-  ///
-  /// If you wish to disable this behavior, you can run the [work] in a separate [Zone]
-  /// with `zoneValues: {#sequentialWorkQueueNoWaitForAsync: true}` set.
   ///
   /// You can optionally pass [onCancel] that will be called
   /// if something attempts to clear this [SequentialWorkQueue] with methods like [clear].
@@ -82,363 +81,391 @@ class SequentialWorkQueue {
   /// // Prints: 1, 2, 3
   /// ```
   Future<T?> add<T extends Object?>(
-    FutureOr<T> Function() work, [
+    FutureOr<T> Function() work, {
     FutureOr<bool> Function()? onCancel,
-  ]) async {
-    final tCompleter = Completer<void>();
-    final tQueueItem = _SequentialWorkQueueItem(tCompleter, work, onCancel);
-    _queue.add(tQueueItem);
+    bool waitForMicrotasks = true,
+    bool waitForTimers = false,
+    bool waitForPeriodicTimers = false,
+  }) {
+    return _runInSafeZone(() async {
+      final tCompleter = Completer<void>();
+      final tQueueItem = _SequentialWorkQueueItem(tCompleter, work, onCancel);
+      _queue.add(tQueueItem);
 
-    final tValueCompleter = Completer<T?>();
+      final tValueCompleter = Completer<T?>();
 
-    Future<void> fFinish(
-      bool cancel,
-      T? value, [
-      Object? error,
-      StackTrace? stackTrace,
-    ]) async {
-      if (!cancel) {
-        // This should only be called once.
+      Future<void> fFinish(
+        bool cancel,
+        T? value, [
+        Object? error,
+        StackTrace? stackTrace,
+      ]) async {
+        return _runInSafeZone(() async {
+          if (!cancel) {
+            // This should only be called once.
 
-        // Wait for all async work to complete.
-        while (tQueueItem.asyncQueue.isNotEmpty) {
-          await tQueueItem.asyncQueue.removeFirst();
+            // Wait for all async work to complete.
+            while (tQueueItem.asyncQueue.isNotEmpty) {
+              await tQueueItem.asyncQueue.removeFirst();
+
+              if (tQueueItem.cancelled) {
+                // We got cancelled while waiting.
+                // Clean up a bit and just return.
+                // If we are cancelled, that means the cancel condition
+                // of the above code has already been met and we don't need
+                // to do anything else.
+                tQueueItem.asyncQueue.clear();
+
+                return;
+              }
+            }
+          }
+
+          if (!tCompleter.isCompleted) {
+            tQueueItem.unlink();
+            tCompleter.complete();
+          }
+
+          if (!tValueCompleter.isCompleted) {
+            if (error != null) {
+              tValueCompleter.completeError(error, stackTrace);
+            } else {
+              tValueCompleter.complete(value);
+            }
+          }
+        });
+      }
+
+      try {
+        if (tQueueItem.previous != null) {
+          await tQueueItem.previous!.completer.future;
 
           if (tQueueItem.cancelled) {
-            // We got cancelled while waiting.
-            // Clean up a bit and just return.
-            // If we are cancelled, that means the cancel condition
-            // of the above code has already been met and we don't need
-            // to do anything else.
-            tQueueItem.asyncQueue.clear();
-
-            return;
+            fFinish(true, null);
+            return tValueCompleter.future;
           }
         }
-      }
 
-      if (!tCompleter.isCompleted) {
-        tQueueItem.unlink();
-        tCompleter.complete();
-      }
+        runZoned<void>(
+          () {
+            try {
+              final tResult = work();
 
-      if (!tValueCompleter.isCompleted) {
-        if (error != null) {
-          tValueCompleter.completeError(error, stackTrace);
-        } else {
-          tValueCompleter.complete(value);
-        }
-      }
-    }
+              if (tResult != null) {
+                if (tResult is Future<T>) {
+                  _runInSafeZone(() {
+                    final tSafeZone = Zone.current;
+                    final fOnResult = tSafeZone.bindUnaryCallback<void, T>(
+                      (value) {
+                        fFinish(false, value);
+                      },
+                    );
+                    final tOnError = tSafeZone
+                        .bindBinaryCallback<void, Object?, StackTrace>(
+                            (error, stackTrace) {
+                      fFinish(false, null, error, stackTrace);
+                    });
 
-    try {
-      if (tQueueItem.previous != null) {
-        await tQueueItem.previous!.completer.future;
-
-        if (tQueueItem.cancelled) {
-          fFinish(true, null);
-          return tValueCompleter.future;
-        }
-      }
-
-      runZoned<void>(
-        () {
-          try {
-            final tResult = work();
-
-            if (tResult != null) {
-              if (tResult is Future<T>) {
-                tResult.then<void>(
-                  (value) {
-                    fFinish(false, value);
-                  },
-                  onError: (error, stackTrace) {
-                    fFinish(false, null, error, stackTrace);
-                  },
-                );
-              } else {
-                fFinish(false, tResult);
-              }
-            } else {
-              fFinish(false, null);
-            }
-          } catch (error, stackTrace) {
-            fFinish(false, null, error, stackTrace);
-          }
-        },
-        zoneValues: {
-          #sequentialWorkQueue: hashCode,
-          #sequentialWorkQueueItem: tQueueItem.hashCode,
-        },
-        zoneSpecification: ZoneSpecification(
-          fork: (self, parent, zone, specification, zoneValues) {
-            return parent.fork(
-              zone,
-              specification,
-              {
-                ...?zoneValues,
-                // Keep this so we know if we are inside this queue.
-                #sequentialWorkQueue: hashCode,
-                // Reset this so we don't cancel code in this new Zone.
-                #sequentialWorkQueueItem: 0,
-              },
-            );
-          },
-          scheduleMicrotask: (self, parent, zone, f) {
-            late Completer<void> tAsyncCompleter;
-
-            void fCompleteAsync() {
-              parent.run(Zone.current.parent ?? zone, () {
-                tAsyncCompleter.complete();
-              });
-            }
-
-            if (zone[#sequentialWorkQueueItem] != tQueueItem.hashCode) {
-              var tF = f;
-
-              if (zone[#sequentialWorkQueueNoWaitForAsync] != true) {
-                parent.run(Zone.current.parent ?? zone, () {
-                  tAsyncCompleter = Completer<void>();
-                  tQueueItem.asyncQueue.add(tAsyncCompleter.future);
-                });
-
-                tF = () {
-                  fCompleteAsync();
-                  f();
-                };
-              }
-
-              return parent.scheduleMicrotask(zone, tF);
-            }
-
-            parent.run(Zone.current.parent ?? zone, () {
-              tAsyncCompleter = Completer<void>();
-              tQueueItem.asyncQueue.add(tAsyncCompleter.future);
-            });
-
-            parent.scheduleMicrotask(zone, () {
-              if (!tQueueItem.cancelled) {
-                if (tQueueItem.cancellingCompleter != null) {
-                  tQueueItem.cancellingCompleter!.future.then((cancelled) {
-                    fCompleteAsync();
-
-                    if (!cancelled) {
-                      f();
-                    } else {
-                      fFinish(true, null);
-                    }
+                    tResult.then<void>(
+                      fOnResult,
+                      onError: tOnError,
+                    );
                   });
                 } else {
-                  fCompleteAsync();
-                  f();
+                  fFinish(false, tResult);
                 }
               } else {
-                fCompleteAsync();
-                fFinish(true, null);
+                fFinish(false, null);
               }
-            });
-          },
-          createTimer: (self, parent, zone, duration, f) {
-            late Completer<void> tAsyncCompleter;
-
-            void fCompleteAsync() {
-              parent.run(Zone.current.parent ?? zone, () {
-                tAsyncCompleter.complete();
-              });
+            } catch (error, stackTrace) {
+              fFinish(false, null, error, stackTrace);
             }
-
-            if (zone[#sequentialWorkQueueItem] != tQueueItem.hashCode) {
-              var tF = f;
-
-              if (zone[#sequentialWorkQueueNoWaitForAsync] != true) {
-                parent.run(Zone.current.parent ?? zone, () {
-                  tAsyncCompleter = Completer<void>();
-                  tQueueItem.asyncQueue.add(tAsyncCompleter.future);
-                });
-
-                tF = () {
-                  fCompleteAsync();
-                  f();
-                };
-              }
-
-              return parent.createTimer(zone, duration, tF);
-            }
-
-            parent.run(Zone.current.parent ?? zone, () {
-              tAsyncCompleter = Completer<void>();
-              tQueueItem.asyncQueue.add(tAsyncCompleter.future);
-            });
-
-            return parent.createTimer(zone, duration, () {
-              if (!tQueueItem.cancelled) {
-                if (tQueueItem.cancellingCompleter != null) {
-                  tQueueItem.cancellingCompleter!.future.then((cancelled) {
-                    fCompleteAsync();
-
-                    if (!cancelled) {
-                      f();
-                    } else {
-                      fFinish(true, null);
-                    }
-                  });
-                } else {
-                  fCompleteAsync();
-                  f();
-                }
-              } else {
-                fCompleteAsync();
-                fFinish(true, null);
-              }
-            });
           },
-          createPeriodicTimer: (self, parent, zone, period, f) {
-            late Completer<void> tAsyncCompleter;
+          zoneValues: {
+            #sequentialWorkQueue: hashCode,
+            #sequentialWorkQueueItem: tQueueItem.hashCode,
+          },
+          zoneSpecification: ZoneSpecification(
+            fork: (self, parent, zone, specification, zoneValues) {
+              return parent.fork(
+                zone,
+                specification,
+                {
+                  ...?zoneValues,
+                  // Keep this so we know if we are inside this queue.
+                  #sequentialWorkQueue: hashCode,
+                  // Reset this so we don't cancel code in this new Zone.
+                  #sequentialWorkQueueItem: 0,
+                },
+              );
+            },
+            scheduleMicrotask: (self, parent, zone, f) {
+              if (!waitForMicrotasks ||
+                  zone[#sequentialWorkQueueItem] != tQueueItem.hashCode) {
+                return parent.scheduleMicrotask(zone, f);
+              }
 
-            void fCompleteAsync() {
-              if (!tAsyncCompleter.isCompleted) {
-                parent.run(Zone.current.parent ?? zone, () {
+              late Completer<void> tAsyncCompleter;
+
+              void fCompleteAsync() {
+                _runInSafeZone(() {
+                  // When the compiler optimizes the tail end of an await
+                  // call to execute code synchronously across multiple tail ends
+                  // of other awaits and in particular, across the Zone exit
+                  // boundary we care about, the cancellation code will not
+                  // have been run yet.
+                  // Run it here otherwise we get in to a state where
+                  // the value completer never completes.
+                  if (tQueueItem.cancelled &&
+                      tQueueItem.asyncQueue.length == 1) {
+                    fFinish(true, null);
+                  }
+
                   tAsyncCompleter.complete();
                 });
               }
-            }
 
-            if (zone[#sequentialWorkQueueItem] != tQueueItem.hashCode) {
-              var tF = f;
+              final tUnsafeZone = Zone.current;
 
-              if (zone[#sequentialWorkQueueNoWaitForAsync] != true) {
-                parent.run(Zone.current.parent ?? zone, () {
-                  tAsyncCompleter = Completer<void>();
-                  tQueueItem.asyncQueue.add(tAsyncCompleter.future);
+              _runInSafeZone(() {
+                tAsyncCompleter = Completer<void>();
+                tQueueItem.asyncQueue.add(tAsyncCompleter.future);
+
+                Zone.current.scheduleMicrotask(() {
+                  if (!tQueueItem.cancelled) {
+                    if (tQueueItem.cancellingCompleter != null) {
+                      _runInSafeZone(() {
+                        tQueueItem.cancellingCompleter!.future
+                            .then((cancelled) {
+                          fCompleteAsync();
+
+                          if (!cancelled) {
+                            tUnsafeZone.run(f);
+                          } else {
+                            fFinish(true, null);
+                          }
+                        });
+                      });
+                    } else {
+                      fCompleteAsync();
+                      f();
+                    }
+                  } else {
+                    fCompleteAsync();
+                    fFinish(true, null);
+                  }
+                });
+              });
+            },
+            createTimer: (self, parent, zone, duration, f) {
+              if (!waitForTimers ||
+                  zone[#sequentialWorkQueueItem] != tQueueItem.hashCode) {
+                return parent.createTimer(zone, duration, f);
+              }
+
+              late Completer<void> tAsyncCompleter;
+
+              void fCompleteAsync() {
+                _runInSafeZone(() {
+                  tAsyncCompleter.complete();
+                });
+              }
+
+              final tUnsafeZone = Zone.current;
+
+              return _runInSafeZone(() {
+                tAsyncCompleter = Completer<void>();
+                tQueueItem.asyncQueue.add(tAsyncCompleter.future);
+
+                final tBackingTimer = Zone.current.createTimer(duration, () {
+                  if (!tQueueItem.cancelled) {
+                    if (tQueueItem.cancellingCompleter != null) {
+                      _runInSafeZone(() {
+                        tQueueItem.cancellingCompleter!.future
+                            .then((cancelled) {
+                          fCompleteAsync();
+
+                          if (!cancelled) {
+                            tUnsafeZone.run(f);
+                          } else {
+                            fFinish(true, null);
+                          }
+                        });
+                      });
+                    } else {
+                      fCompleteAsync();
+                      f();
+                    }
+                  } else {
+                    fCompleteAsync();
+                    fFinish(true, null);
+                  }
                 });
 
-                tF = (Timer timer) {
-                  fCompleteAsync();
-                  f(timer);
-                };
-              }
-
-              return parent.createPeriodicTimer(zone, period, tF);
-            }
-
-            parent.run(Zone.current.parent ?? zone, () {
-              tAsyncCompleter = Completer<void>();
-              tQueueItem.asyncQueue.add(tAsyncCompleter.future);
-            });
-
-            late final _PeriodicTimer tTimer;
-
-            final tBackingTimer =
-                parent.createPeriodicTimer(zone, period, (timer) {
-              if (!tQueueItem.cancelled) {
-                if (tQueueItem.cancellingCompleter != null) {
-                  tQueueItem.cancellingCompleter!.future.then((cancelled) {
-                    if (!cancelled) {
-                      f(tTimer);
-                    } else {
-                      tTimer.cancelWithoutCallback();
+                final tTimer = _TimerWithCancelCallback(
+                  tBackingTimer,
+                  // This callback happens when the timer is cancelled.
+                  () {
+                    if (!tAsyncCompleter.isCompleted) {
+                      // Notify that this timer has been cancelled.
+                      // This will let the future for [add] to complete.
                       fCompleteAsync();
-                      fFinish(true, null);
                     }
-                  });
-                } else {
-                  f(tTimer);
-                }
-              } else {
-                tTimer.cancelWithoutCallback();
-                fCompleteAsync();
-                fFinish(true, null);
+                  },
+                );
+
+                return tTimer;
+              });
+            },
+            createPeriodicTimer: (self, parent, zone, period, f) {
+              if (!waitForPeriodicTimers ||
+                  zone[#sequentialWorkQueueItem] != tQueueItem.hashCode) {
+                return parent.createPeriodicTimer(zone, period, f);
               }
-            });
 
-            tTimer = _PeriodicTimer(
-              tBackingTimer,
-              // This callback happens when the timer is cancelled.
-              () {
-                if (!tAsyncCompleter.isCompleted) {
-                  // Notify that this timer has been cancelled.
-                  // This will let the future for [add] to complete.
-                  fCompleteAsync();
-                }
-              },
-            );
+              late Completer<void> tAsyncCompleter;
 
-            return tTimer;
-          },
-        ),
-      );
-    } catch (error, stackTrace) {
-      // If we get here, something went wrong.
-      // Can't think of a possible realistic code path
-      // that would cause this to happen, so we will ignore
-      // this line for coverage.
-      // coverage:ignore-start
-      fFinish(false, null, error, stackTrace);
-      // coverage:ignore-end
-    }
+              void fCompleteAsync() {
+                _runInSafeZone(() {
+                  if (!tAsyncCompleter.isCompleted) {
+                    tAsyncCompleter.complete();
+                  }
+                });
+              }
 
-    return tValueCompleter.future;
+              final tUnsafeZone = Zone.current;
+
+              return _runInSafeZone(() {
+                tAsyncCompleter = Completer<void>();
+                tQueueItem.asyncQueue.add(tAsyncCompleter.future);
+
+                late final _TimerWithCancelCallback tTimer;
+
+                final tBackingTimer =
+                    Zone.current.createPeriodicTimer(period, (timer) {
+                  if (!tQueueItem.cancelled) {
+                    if (tQueueItem.cancellingCompleter != null) {
+                      _runInSafeZone(() {
+                        tQueueItem.cancellingCompleter!.future
+                            .then((cancelled) {
+                          if (!cancelled) {
+                            tUnsafeZone.runUnary(f, tTimer);
+                          } else {
+                            tTimer.cancelWithoutCallback();
+                            fCompleteAsync();
+                            fFinish(true, null);
+                          }
+                        });
+                      });
+                    } else {
+                      f(tTimer);
+                    }
+                  } else {
+                    tTimer.cancelWithoutCallback();
+                    fCompleteAsync();
+                    fFinish(true, null);
+                  }
+                });
+
+                tTimer = _TimerWithCancelCallback(
+                  tBackingTimer,
+                  // This callback happens when the timer is cancelled.
+                  () {
+                    if (!tAsyncCompleter.isCompleted) {
+                      // Notify that this timer has been cancelled.
+                      // This will let the future for [add] to complete.
+                      fCompleteAsync();
+                    }
+                  },
+                );
+
+                return tTimer;
+              });
+            },
+          ),
+        );
+      } catch (error, stackTrace) {
+        // If we get here, something went wrong.
+        // Can't think of a possible realistic code path
+        // that would cause this to happen, so we will ignore
+        // this line for coverage.
+        // coverage:ignore-start
+        fFinish(false, null, error, stackTrace);
+        // coverage:ignore-end
+      }
+
+      return tValueCompleter.future;
+    });
   }
 
   /// Clear the queue.
-  /// This is attempt to cancel all work pending and running.
+  /// This will attempt to cancel all work pending and running.
   /// It will return when all work has truly completed or cancelled.
   ///
-  /// Warning. Never call this inside [SequentialWorkQueue.add.work].
-  /// An assert will be thrown, or in release mode, ignored.
-  Future<void> clear() async {
-    assert(Zone.current[#sequentialWorkQueueItem] == null,
-        'Can not clear() a SequentialWorkQueue inside a work callback.');
+  /// If a work callback is current executing and is cancelable,
+  /// the work itself will cancel however any async work scheduled
+  /// inside a child [Zone] via [runZone] and friends will not be cancelled.
+  /// Ie, microtasks, timers, and futures will not be cancelled.
+  ///
+  /// This function will always execute in the closest parent [Zone] that
+  /// isn't a special [Zone] created by [add].
+  /// This means that if you call this function inside a [work] function
+  /// added to this [SequentialWorkQueue], due to the [Zone] changing, awaiting
+  /// for this function will not actually wait for it to finish.
+  /// In general, you should probably not use await with this function
+  /// if you are inside a [work] function.
+  Future<void> clear() {
+    return _runInSafeZone(() async {
+      final tQueue = _queue
+          .where((element) => element.cancellingCompleter == null)
+          .toList(growable: false);
 
-    final tQueue = _queue
-        .where((element) => element.cancellingCompleter == null)
-        .toList(growable: false);
+      for (var i in tQueue) {
+        i.cancellingCompleter = Completer<bool>();
+      }
 
-    for (var i in tQueue) {
-      i.cancellingCompleter = Completer<bool>();
-    }
+      final tWorkToWaitFor = <Future<void>>[];
 
-    final tWorkToWaitFor = <Future<void>>[];
+      for (var i in tQueue) {
+        final tCompleter = i.cancellingCompleter!;
+        tWorkToWaitFor.add(i.completer.future);
 
-    for (var i in tQueue) {
-      final tCompleter = i.cancellingCompleter!;
-      tWorkToWaitFor.add(i.completer.future);
+        if (i.onCancel != null) {
+          try {
+            final tCancelResult = i.onCancel!();
 
-      if (i.onCancel != null) {
-        try {
-          final tCancelResult = i.onCancel!();
-
-          if (tCancelResult == true) {
-            i.cancelled = true;
-            tCompleter.complete(true);
-          } else if (tCancelResult == false) {
-            i.cancellingCompleter = null;
-            tCompleter.complete(false);
-          } else {
-            final tCancelFinalResult = await tCancelResult;
-
-            if (tCancelFinalResult) {
+            if (tCancelResult == true) {
               i.cancelled = true;
               tCompleter.complete(true);
-            } else {
+            } else if (tCancelResult == false) {
               i.cancellingCompleter = null;
               tCompleter.complete(false);
-            }
-          }
-        } catch (error, stackTrace) {
-          // Continue processing the queue.
-          // We will send this off to the zone unhandled callback.
-          i.cancellingCompleter = null;
-          tCompleter.complete(false);
-          Zone.current.handleUncaughtError(error, stackTrace);
-        }
-      } else {
-        i.cancelled = true;
-        tCompleter.complete(true);
-      }
-    }
+            } else {
+              final tCancelFinalResult = await tCancelResult;
 
-    await Future.wait(tWorkToWaitFor);
+              if (tCancelFinalResult) {
+                i.cancelled = true;
+                tCompleter.complete(true);
+              } else {
+                i.cancellingCompleter = null;
+                tCompleter.complete(false);
+              }
+            }
+          } catch (error, stackTrace) {
+            // Continue processing the queue.
+            // We will send this off to the zone unhandled callback.
+            i.cancellingCompleter = null;
+            tCompleter.complete(false);
+            Zone.current.handleUncaughtError(error, stackTrace);
+          }
+        } else {
+          i.cancelled = true;
+          tCompleter.complete(true);
+        }
+      }
+
+      await Future.wait(tWorkToWaitFor);
+    });
   }
 
   /// Whether this queue is empty
@@ -446,13 +473,29 @@ class SequentialWorkQueue {
 
   /// Whether this queue is not empty
   bool get isNotEmpty => _queue.isNotEmpty;
+
+  T _runInSafeZone<T>(T Function() f) {
+    var tZoneToExecuteIn = Zone.current;
+
+    if (tZoneToExecuteIn[#sequentialWorkQueueItem] != null) {
+      // We are inside the queue.
+      // We will need to run this in the parent zone.
+      do {
+        tZoneToExecuteIn = tZoneToExecuteIn.parent!;
+      } while (tZoneToExecuteIn[#sequentialWorkQueueItem] != null);
+
+      return tZoneToExecuteIn.run<T>(f);
+    }
+
+    return f();
+  }
 }
 
-class _PeriodicTimer implements Timer {
+class _TimerWithCancelCallback implements Timer {
   final Timer backingTimer;
   final void Function() onCancel;
 
-  _PeriodicTimer(this.backingTimer, this.onCancel);
+  _TimerWithCancelCallback(this.backingTimer, this.onCancel);
 
   @override
   void cancel() {

--- a/packages/patapata_core/test/util_test.dart
+++ b/packages/patapata_core/test/util_test.dart
@@ -124,13 +124,13 @@ void main() {
 
       tFutures.add(tQueue.add<void>(() {
         tValue += '0';
-      }, () => true));
+      }, onCancel: () => true));
 
       tQueue.clear();
 
       tFutures.add(tQueue.add<void>(() {
         tValue += '1';
-      }, () => true));
+      }, onCancel: () => true));
 
       while (tFutures.isNotEmpty) {
         final tFuturesCopy = tFutures.toList();
@@ -152,13 +152,13 @@ void main() {
       tFutures.add(tQueue.add<void>(() async {
         await Future.microtask(() => null);
         tValue += '0';
-      }, () async => await Future.microtask(() => true)));
+      }, onCancel: () async => await Future.microtask(() => true)));
 
       tQueue.clear();
 
       tFutures.add(tQueue.add<void>(() {
         tValue += '1';
-      }, () async => true));
+      }, onCancel: () async => true));
 
       while (tFutures.isNotEmpty) {
         final tFuturesCopy = tFutures.toList();
@@ -180,25 +180,25 @@ void main() {
       tFutures.add(tQueue.add<void>(() async {
         await Future.microtask(() => null);
         tValue += '0';
-      }, () async => await Future.microtask(() => true)));
+      }, onCancel: () async => await Future.microtask(() => true)));
 
       tFutures.add(tQueue.add<void>(() async {
         await Future.microtask(() => null);
         tValue += '0';
-      }, () async => await Future.microtask(() => true)));
+      }, onCancel: () async => await Future.microtask(() => true)));
 
       tQueue.clear();
 
       tFutures.add(tQueue.add<void>(() async {
         await Future.microtask(() => null);
         tValue += '0';
-      }, () async => await Future.microtask(() => true)));
+      }, onCancel: () async => await Future.microtask(() => true)));
 
       tQueue.clear();
 
       tFutures.add(tQueue.add<void>(() {
         tValue += '1';
-      }, () async => true));
+      }, onCancel: () async => true));
 
       while (tFutures.isNotEmpty) {
         final tFuturesCopy = tFutures.toList();
@@ -220,13 +220,13 @@ void main() {
       tFutures.add(tQueue.add<void>(() async {
         await Future.microtask(() => null);
         tValue += '0';
-      }, () async => await Future.microtask(() => false)));
+      }, onCancel: () async => await Future.microtask(() => false)));
 
       tQueue.clear();
 
       tFutures.add(tQueue.add<void>(() {
         tValue += '1';
-      }, () async => true));
+      }, onCancel: () async => true));
 
       while (tFutures.isNotEmpty) {
         final tFuturesCopy = tFutures.toList();


### PR DESCRIPTION
- feat: allow to choose whether to wait for microtasks, timers, and periodic timers in a SequentialWorkQueue, as well as ProviderModel's lock function.
- feat: remove the limitation of not being able to add to a SequentialWorkQueue inside the work callback of a SequentialWorkQueue.
- fix: make sure SequentialWorkQueue's processes can't cancel themselves.

# Issue Number
fixes #7

# Summary
- This PR makes using the SequentialWorkQueue system a bit easier in complex situation dealing with Futures, microtasks, timers, etc.
- This PR lets you choose if you would like to wait for the completion of the above mentioned dart features before letting the next work in the queue run.