### PR TITLE
Flutter 3.24.4 Support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         flutterVersion:
-          - '3.22.0'
-          - '3.19.0'
+          - '3.24.0'
+          - '3.24.4'
 
     steps:
       - uses: actions/checkout@v3

--- a/packages/patapata_adjust/pubspec.yaml
+++ b/packages/patapata_adjust/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_adjust
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/patapata_apple_push_notifications/pubspec.yaml
+++ b/packages/patapata_apple_push_notifications/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_apple_p
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/patapata_apps_flyer/pubspec.yaml
+++ b/packages/patapata_apps_flyer/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_apps_fl
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/patapata_core/README.md
+++ b/packages/patapata_core/README.md
@@ -78,7 +78,7 @@ We try to support the newest version of Flutter and will not purposely keep supp
 
 The Patapata team believes that it is important to keep up to date with the latest version of Flutter as in our expierence with real world applications, old versions of Flutter have trouble supporting the newer versions of Android and especially iOS.
 
-Currently, we support Flutter 3.19.0 and above, with a minimum Dart version of 3.0.0 up to 4.0.0.
+Currently, we support Flutter 3.24.0 and above, with a minimum Dart version of 3.0.0 up to 4.0.0.
 
 We officially support Android, iOS fully, and best effort for Web and MacOS.
 Windows and Linux are currently not supported.

--- a/packages/patapata_core/lib/src/widgets/standard_page.dart
+++ b/packages/patapata_core/lib/src/widgets/standard_page.dart
@@ -1040,6 +1040,8 @@ abstract class StandardPageWithResult<T extends Object?, E extends Object?>
         _navigator = Navigator(
           key: _childNavigatorKey,
           pages: _pageChildInstances![tParentPageInstance]!,
+          // TODO: To be addressed in the future.
+          // ignore: deprecated_member_use
           onPopPage: (route, result) {
             if (_delegate?.willPopPage != null) {
               if (_delegate!.willPopPage!(route, result)) {
@@ -1424,6 +1426,8 @@ class StandardRouterDelegate extends RouterDelegate<StandardRouteData>
         routeObserver,
       ],
       pages: _pageInstances,
+      // TODO: To be addressed in the future.
+      // ignore: deprecated_member_use
       onPopPage: _onPopPage,
     );
 

--- a/packages/patapata_core/pubspec.yaml
+++ b/packages/patapata_core/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_core
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 executables:
   bootstrap:

--- a/packages/patapata_firebase_analytics/pubspec.yaml
+++ b/packages/patapata_firebase_analytics/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_firebas
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/patapata_firebase_auth/pubspec.yaml
+++ b/packages/patapata_firebase_auth/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_firebas
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/patapata_firebase_core/pubspec.yaml
+++ b/packages/patapata_firebase_core/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_firebas
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/patapata_firebase_crashlytics/pubspec.yaml
+++ b/packages/patapata_firebase_crashlytics/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_firebas
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/patapata_firebase_dynamic_links/pubspec.yaml
+++ b/packages/patapata_firebase_dynamic_links/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_firebas
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/patapata_firebase_messaging/pubspec.yaml
+++ b/packages/patapata_firebase_messaging/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_firebas
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/patapata_firebase_remote_config/pubspec.yaml
+++ b/packages/patapata_firebase_remote_config/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_firebas
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/patapata_karte_core/pubspec.yaml
+++ b/packages/patapata_karte_core/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_karte_c
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/patapata_karte_variables/pubspec.yaml
+++ b/packages/patapata_karte_variables/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_karte_v
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/patapata_riverpod/lib/src/providers.dart
+++ b/packages/patapata_riverpod/lib/src/providers.dart
@@ -12,28 +12,28 @@ part 'providers.g.dart';
 
 /// The [App] instance.
 @riverpod
-App app(AppRef ref) {
+App app(Ref ref) {
   return getApp();
 }
 
 /// The current [User].
 /// Whenever [User] changes, this provider will be updated.
 @riverpod
-Raw<User> user(UserRef ref) {
+Raw<User> user(Ref ref) {
   return ref.disposeAndListenChangeNotifier(ref.read(appProvider).user);
 }
 
 /// Access to [RemoteConfig].
 /// Whenever [RemoteConfig] changes, this provider will be updated.
 @riverpod
-Raw<RemoteConfig> remoteConfig(RemoteConfigRef ref) {
+Raw<RemoteConfig> remoteConfig(Ref ref) {
   return ref.disposeAndListenChangeNotifier(ref.read(appProvider).remoteConfig);
 }
 
 /// Gets a [RemoteConfig] value as a [String].
 /// Whenever this [key] changes, this provider will be updated.
 @riverpod
-String remoteConfigString(RemoteConfigStringRef ref, String key,
+String remoteConfigString(Ref ref, String key,
     [String defaultValue = Config.defaultValueForString]) {
   return ref.watch(remoteConfigProvider
       .select((v) => v.getString(key, defaultValue: defaultValue)));
@@ -42,7 +42,7 @@ String remoteConfigString(RemoteConfigStringRef ref, String key,
 /// Gets a [RemoteConfig] value as a [int].
 /// Whenever this [key] changes, this provider will be updated.
 @riverpod
-int remoteConfigInt(RemoteConfigIntRef ref, String key,
+int remoteConfigInt(Ref ref, String key,
     [int defaultValue = Config.defaultValueForInt]) {
   return ref.watch(remoteConfigProvider
       .select((v) => v.getInt(key, defaultValue: defaultValue)));
@@ -51,7 +51,7 @@ int remoteConfigInt(RemoteConfigIntRef ref, String key,
 /// Gets a [RemoteConfig] value as a [double].
 /// Whenever this [key] changes, this provider will be updated.
 @riverpod
-double remoteConfigDouble(RemoteConfigDoubleRef ref, String key,
+double remoteConfigDouble(Ref ref, String key,
     [double defaultValue = Config.defaultValueForDouble]) {
   return ref.watch(remoteConfigProvider
       .select((v) => v.getDouble(key, defaultValue: defaultValue)));
@@ -60,7 +60,7 @@ double remoteConfigDouble(RemoteConfigDoubleRef ref, String key,
 /// Gets a [RemoteConfig] value as a [bool].
 /// Whenever this [key] changes, this provider will be updated.
 @riverpod
-bool remoteConfigBool(RemoteConfigBoolRef ref, String key,
+bool remoteConfigBool(Ref ref, String key,
     [bool defaultValue = Config.defaultValueForBool]) {
   return ref.watch(remoteConfigProvider
       .select((v) => v.getBool(key, defaultValue: defaultValue)));
@@ -69,14 +69,14 @@ bool remoteConfigBool(RemoteConfigBoolRef ref, String key,
 /// Access to [LocalConfig].
 /// Whenever [LocalConfig] changes, this provider will be updated.
 @riverpod
-Raw<LocalConfig> localConfig(LocalConfigRef ref) {
+Raw<LocalConfig> localConfig(Ref ref) {
   return ref.disposeAndListenChangeNotifier(ref.read(appProvider).localConfig);
 }
 
 /// Gets a [LocalConfig] value as a [String].
 /// Whenever this [key] changes, this provider will be updated.
 @riverpod
-String localConfigString(LocalConfigStringRef ref, String key,
+String localConfigString(Ref ref, String key,
     [String defaultValue = Config.defaultValueForString]) {
   return ref.watch(localConfigProvider
       .select((v) => v.getString(key, defaultValue: defaultValue)));
@@ -85,7 +85,7 @@ String localConfigString(LocalConfigStringRef ref, String key,
 /// Gets a [LocalConfig] value as a [int].
 /// Whenever this [key] changes, this provider will be updated.
 @riverpod
-int localConfigInt(LocalConfigIntRef ref, String key,
+int localConfigInt(Ref ref, String key,
     [int defaultValue = Config.defaultValueForInt]) {
   return ref.watch(localConfigProvider
       .select((v) => v.getInt(key, defaultValue: defaultValue)));
@@ -94,7 +94,7 @@ int localConfigInt(LocalConfigIntRef ref, String key,
 /// Gets a [LocalConfig] value as a [double].
 /// Whenever this [key] changes, this provider will be updated.
 @riverpod
-double localConfigDouble(LocalConfigDoubleRef ref, String key,
+double localConfigDouble(Ref ref, String key,
     [double defaultValue = Config.defaultValueForDouble]) {
   return ref.watch(localConfigProvider
       .select((v) => v.getDouble(key, defaultValue: defaultValue)));
@@ -103,7 +103,7 @@ double localConfigDouble(LocalConfigDoubleRef ref, String key,
 /// Gets a [LocalConfig] value as a [bool].
 /// Whenever this [key] changes, this provider will be updated.
 @riverpod
-bool localConfigBool(LocalConfigBoolRef ref, String key,
+bool localConfigBool(Ref ref, String key,
     [bool defaultValue = Config.defaultValueForBool]) {
   return ref.watch(localConfigProvider
       .select((v) => v.getBool(key, defaultValue: defaultValue)));
@@ -112,7 +112,7 @@ bool localConfigBool(LocalConfigBoolRef ref, String key,
 /// Access to [RemoteMessaging].
 /// Whenever [RemoteMessaging] changes, this provider will be updated.
 @riverpod
-Raw<RemoteMessaging> remoteMessaging(RemoteMessagingRef ref) {
+Raw<RemoteMessaging> remoteMessaging(Ref ref) {
   return ref
       .disposeAndListenChangeNotifier(ref.read(appProvider).remoteMessaging);
 }
@@ -121,8 +121,7 @@ Raw<RemoteMessaging> remoteMessaging(RemoteMessagingRef ref) {
 /// Whenever a new [RemoteMessage] is receieved via [RemoteMessaging.messages], this provider will be updated.
 /// The first execution of this will return the initial message from [RemoteMessaging.getInitialMessage].
 @riverpod
-Stream<RemoteMessage> remoteMessagingMessages(
-    RemoteMessagingMessagesRef ref) async* {
+Stream<RemoteMessage> remoteMessagingMessages(Ref ref) async* {
   final tRemoteMessaging = ref.watch(remoteMessagingProvider);
 
   final tInitialMessage = await tRemoteMessaging.getInitialMessage();
@@ -138,7 +137,7 @@ Stream<RemoteMessage> remoteMessagingMessages(
 /// Whenever a new token is receieved via [RemoteMessaging.tokens], this provider will be updated.
 /// The first execution of this will return the current token from [RemoteMessaging.getToken].
 @riverpod
-Stream<String?> remoteMessagingTokens(RemoteMessagingTokensRef ref) async* {
+Stream<String?> remoteMessagingTokens(Ref ref) async* {
   final tRemoteMessaging = ref.watch(remoteMessagingProvider);
 
   yield await tRemoteMessaging.getToken();
@@ -147,20 +146,20 @@ Stream<String?> remoteMessagingTokens(RemoteMessagingTokensRef ref) async* {
 
 /// Access to [Analytics].
 @riverpod
-Analytics analytics(AnalyticsRef ref) {
+Analytics analytics(Ref ref) {
   return ref.read(appProvider).analytics;
 }
 
 /// Access to the global [AnalyticsContext] from [Analytics.globalContext].
 @riverpod
-AnalyticsContext globalAnalyticsContext(GlobalAnalyticsContextRef ref) {
+AnalyticsContext globalAnalyticsContext(Ref ref) {
   return ref.read(analyticsProvider).globalContext;
 }
 
 /// Access to a stream of [NetworkInformation].
 /// Whenever [NetworkInformation] changes, this provider will be updated.
 @riverpod
-NetworkInformation networkInformation(NetworkInformationRef ref) {
+NetworkInformation networkInformation(Ref ref) {
   final tNetworkPlugin = ref.read(appProvider).getPlugin<NetworkPlugin>()!;
 
   final tSubscription = tNetworkPlugin.informationStream.listen((event) {
@@ -174,13 +173,13 @@ NetworkInformation networkInformation(NetworkInformationRef ref) {
 
 /// Access to [PackageInfo].
 @riverpod
-PackageInfoPlugin packageInfo(PackageInfoRef ref) {
+PackageInfoPlugin packageInfo(Ref ref) {
   return ref.read(appProvider).package;
 }
 
 /// Access to [DeviceInfo].
 @riverpod
-DeviceInfoPlugin deviceInfo(DeviceInfoRef ref) {
+DeviceInfoPlugin deviceInfo(Ref ref) {
   return ref.read(appProvider).device;
 }
 

--- a/packages/patapata_riverpod/lib/src/providers.g.dart
+++ b/packages/patapata_riverpod/lib/src/providers.g.dart
@@ -11,7 +11,7 @@ part of 'providers.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$appHash() => r'b221fc2a0f1007056310f6ab8af4b3bdb50f2ecc';
+String _$appHash() => r'a386eda9ca296deee36af71770b18e030ea7fa01';
 
 /// The [App] instance.
 ///
@@ -26,8 +26,10 @@ final appProvider = AutoDisposeProvider<App>.internal(
   allTransitiveDependencies: null,
 );
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 typedef AppRef = AutoDisposeProviderRef<App>;
-String _$userHash() => r'185492973048a3679bb21cb6e2bf4ce15012ec7e';
+String _$userHash() => r'b7f4b2123aac513b4e6995ec4b0568dcc3aa0c6c';
 
 /// The current [User].
 /// Whenever [User] changes, this provider will be updated.
@@ -43,8 +45,10 @@ final userProvider = AutoDisposeProvider<Raw<User>>.internal(
   allTransitiveDependencies: null,
 );
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 typedef UserRef = AutoDisposeProviderRef<Raw<User>>;
-String _$remoteConfigHash() => r'8e75aba0bc4b5c62efcad5a0d20aba8538c17cd3';
+String _$remoteConfigHash() => r'f4f49484ad446cc9577c644c46c75b76c5e330b6';
 
 /// Access to [RemoteConfig].
 /// Whenever [RemoteConfig] changes, this provider will be updated.
@@ -60,9 +64,11 @@ final remoteConfigProvider = AutoDisposeProvider<Raw<RemoteConfig>>.internal(
   allTransitiveDependencies: null,
 );
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 typedef RemoteConfigRef = AutoDisposeProviderRef<Raw<RemoteConfig>>;
 String _$remoteConfigStringHash() =>
-    r'd3defab5f7870a383673f72bbe259deb968ff000';
+    r'6fa9cc31e55d7e7a76899ab404ee562fa0dc26d9';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -228,6 +234,8 @@ class RemoteConfigStringProvider extends AutoDisposeProvider<String> {
   }
 }
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 mixin RemoteConfigStringRef on AutoDisposeProviderRef<String> {
   /// The parameter `key` of this provider.
   String get key;
@@ -247,7 +255,7 @@ class _RemoteConfigStringProviderElement
       (origin as RemoteConfigStringProvider).defaultValue;
 }
 
-String _$remoteConfigIntHash() => r'102555b16644b3768133e933fbb7e6b4e84efe61';
+String _$remoteConfigIntHash() => r'a69bc4ad3ef9a8e2e8d91ed3e1070c1f71fe1157';
 
 /// Gets a [RemoteConfig] value as a [int].
 /// Whenever this [key] changes, this provider will be updated.
@@ -392,6 +400,8 @@ class RemoteConfigIntProvider extends AutoDisposeProvider<int> {
   }
 }
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 mixin RemoteConfigIntRef on AutoDisposeProviderRef<int> {
   /// The parameter `key` of this provider.
   String get key;
@@ -411,7 +421,7 @@ class _RemoteConfigIntProviderElement extends AutoDisposeProviderElement<int>
 }
 
 String _$remoteConfigDoubleHash() =>
-    r'f7cf93febfff6eab6e48c05bb7aa177e31aaf84b';
+    r'fc88e6237a28490b6c6c5b76b471714cff3f6993';
 
 /// Gets a [RemoteConfig] value as a [double].
 /// Whenever this [key] changes, this provider will be updated.
@@ -556,6 +566,8 @@ class RemoteConfigDoubleProvider extends AutoDisposeProvider<double> {
   }
 }
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 mixin RemoteConfigDoubleRef on AutoDisposeProviderRef<double> {
   /// The parameter `key` of this provider.
   String get key;
@@ -575,7 +587,7 @@ class _RemoteConfigDoubleProviderElement
       (origin as RemoteConfigDoubleProvider).defaultValue;
 }
 
-String _$remoteConfigBoolHash() => r'13a9e5417b965b88f843d5fa69b7cb03cb9fea95';
+String _$remoteConfigBoolHash() => r'15dc8fae111c031129a09354ab7fca16b545899d';
 
 /// Gets a [RemoteConfig] value as a [bool].
 /// Whenever this [key] changes, this provider will be updated.
@@ -720,6 +732,8 @@ class RemoteConfigBoolProvider extends AutoDisposeProvider<bool> {
   }
 }
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 mixin RemoteConfigBoolRef on AutoDisposeProviderRef<bool> {
   /// The parameter `key` of this provider.
   String get key;
@@ -738,7 +752,7 @@ class _RemoteConfigBoolProviderElement extends AutoDisposeProviderElement<bool>
   bool get defaultValue => (origin as RemoteConfigBoolProvider).defaultValue;
 }
 
-String _$localConfigHash() => r'2d0900f1e1f41f25456b738fcc2a18d4fd7cca59';
+String _$localConfigHash() => r'd0fd0c12e8ac890c2b7681a8fb3f5790f5f3d67f';
 
 /// Access to [LocalConfig].
 /// Whenever [LocalConfig] changes, this provider will be updated.
@@ -754,8 +768,10 @@ final localConfigProvider = AutoDisposeProvider<Raw<LocalConfig>>.internal(
   allTransitiveDependencies: null,
 );
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 typedef LocalConfigRef = AutoDisposeProviderRef<Raw<LocalConfig>>;
-String _$localConfigStringHash() => r'5d87800e6aa2139e9129dba2d78145a941927fc5';
+String _$localConfigStringHash() => r'1e5e30c43a240dd52f7fff8a02d23d8c6c28a9b8';
 
 /// Gets a [LocalConfig] value as a [String].
 /// Whenever this [key] changes, this provider will be updated.
@@ -900,6 +916,8 @@ class LocalConfigStringProvider extends AutoDisposeProvider<String> {
   }
 }
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 mixin LocalConfigStringRef on AutoDisposeProviderRef<String> {
   /// The parameter `key` of this provider.
   String get key;
@@ -918,7 +936,7 @@ class _LocalConfigStringProviderElement
   String get defaultValue => (origin as LocalConfigStringProvider).defaultValue;
 }
 
-String _$localConfigIntHash() => r'4050a4918e2d6b5b05931444019231f0dd3def14';
+String _$localConfigIntHash() => r'd7bd540bfb506417c059d5af13c6712644700216';
 
 /// Gets a [LocalConfig] value as a [int].
 /// Whenever this [key] changes, this provider will be updated.
@@ -1063,6 +1081,8 @@ class LocalConfigIntProvider extends AutoDisposeProvider<int> {
   }
 }
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 mixin LocalConfigIntRef on AutoDisposeProviderRef<int> {
   /// The parameter `key` of this provider.
   String get key;
@@ -1081,7 +1101,7 @@ class _LocalConfigIntProviderElement extends AutoDisposeProviderElement<int>
   int get defaultValue => (origin as LocalConfigIntProvider).defaultValue;
 }
 
-String _$localConfigDoubleHash() => r'177c15a70d201d5ec197ec3569a654193b6297fb';
+String _$localConfigDoubleHash() => r'4f2de71381d06b9ab23530ff8b516186d8ac69d1';
 
 /// Gets a [LocalConfig] value as a [double].
 /// Whenever this [key] changes, this provider will be updated.
@@ -1226,6 +1246,8 @@ class LocalConfigDoubleProvider extends AutoDisposeProvider<double> {
   }
 }
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 mixin LocalConfigDoubleRef on AutoDisposeProviderRef<double> {
   /// The parameter `key` of this provider.
   String get key;
@@ -1244,7 +1266,7 @@ class _LocalConfigDoubleProviderElement
   double get defaultValue => (origin as LocalConfigDoubleProvider).defaultValue;
 }
 
-String _$localConfigBoolHash() => r'45ff874a484e20c2ae29d4113d77914e6cf46696';
+String _$localConfigBoolHash() => r'c818ba2223a40f13130a32696df6e77e25bc18b4';
 
 /// Gets a [LocalConfig] value as a [bool].
 /// Whenever this [key] changes, this provider will be updated.
@@ -1389,6 +1411,8 @@ class LocalConfigBoolProvider extends AutoDisposeProvider<bool> {
   }
 }
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 mixin LocalConfigBoolRef on AutoDisposeProviderRef<bool> {
   /// The parameter `key` of this provider.
   String get key;
@@ -1407,7 +1431,7 @@ class _LocalConfigBoolProviderElement extends AutoDisposeProviderElement<bool>
   bool get defaultValue => (origin as LocalConfigBoolProvider).defaultValue;
 }
 
-String _$remoteMessagingHash() => r'3202165a9ba8b104810ce6db9ab4a689b08397f3';
+String _$remoteMessagingHash() => r'dbe187f77269933c293bea5e45657c378c8fdf7a';
 
 /// Access to [RemoteMessaging].
 /// Whenever [RemoteMessaging] changes, this provider will be updated.
@@ -1425,9 +1449,11 @@ final remoteMessagingProvider =
   allTransitiveDependencies: null,
 );
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 typedef RemoteMessagingRef = AutoDisposeProviderRef<Raw<RemoteMessaging>>;
 String _$remoteMessagingMessagesHash() =>
-    r'cceead0236a21e44607e4fdd1fb2e064ec52f6ae';
+    r'8285f650cf673fd0645e5b0c3cf8b65b0cd6de9f';
 
 /// Access to [RemoteMessaging.messages].
 /// Whenever a new [RemoteMessage] is receieved via [RemoteMessaging.messages], this provider will be updated.
@@ -1446,10 +1472,12 @@ final remoteMessagingMessagesProvider =
   allTransitiveDependencies: null,
 );
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 typedef RemoteMessagingMessagesRef
     = AutoDisposeStreamProviderRef<RemoteMessage>;
 String _$remoteMessagingTokensHash() =>
-    r'b336b909e5704473fc7b36dfa176063c7a9c66c2';
+    r'84ae2672e5cbe8686f5a9861ced71279165895a3';
 
 /// Access to [RemoteMessaging.tokens].
 /// Whenever a new token is receieved via [RemoteMessaging.tokens], this provider will be updated.
@@ -1468,8 +1496,10 @@ final remoteMessagingTokensProvider =
   allTransitiveDependencies: null,
 );
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 typedef RemoteMessagingTokensRef = AutoDisposeStreamProviderRef<String?>;
-String _$analyticsHash() => r'1fd69a6ec7906d89d0ebaf111bed072b736dc3f3';
+String _$analyticsHash() => r'449bd835a33a36ee85450b1139172925ec245ba7';
 
 /// Access to [Analytics].
 ///
@@ -1484,9 +1514,11 @@ final analyticsProvider = AutoDisposeProvider<Analytics>.internal(
   allTransitiveDependencies: null,
 );
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 typedef AnalyticsRef = AutoDisposeProviderRef<Analytics>;
 String _$globalAnalyticsContextHash() =>
-    r'0f4421d75f4445217509cff50843e89797133fce';
+    r'20c27a4b507a0be0866e6e8fbda4f78d9ef726f7';
 
 /// Access to the global [AnalyticsContext] from [Analytics.globalContext].
 ///
@@ -1503,9 +1535,11 @@ final globalAnalyticsContextProvider =
   allTransitiveDependencies: null,
 );
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 typedef GlobalAnalyticsContextRef = AutoDisposeProviderRef<AnalyticsContext>;
 String _$networkInformationHash() =>
-    r'13d7cae849d6733c528c329d79f79e1a43d5f53c';
+    r'f512cf8eaa5196f1d499cabe74b2203a2ab7e6a3';
 
 /// Access to a stream of [NetworkInformation].
 /// Whenever [NetworkInformation] changes, this provider will be updated.
@@ -1523,8 +1557,10 @@ final networkInformationProvider =
   allTransitiveDependencies: null,
 );
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 typedef NetworkInformationRef = AutoDisposeProviderRef<NetworkInformation>;
-String _$packageInfoHash() => r'bb4b207e4e72b204cb2ce57645ec41ad09115b53';
+String _$packageInfoHash() => r'eb33e7faec41df692cfc4a05f6ac2f745b8944ea';
 
 /// Access to [PackageInfo].
 ///
@@ -1539,8 +1575,10 @@ final packageInfoProvider = AutoDisposeProvider<PackageInfoPlugin>.internal(
   allTransitiveDependencies: null,
 );
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 typedef PackageInfoRef = AutoDisposeProviderRef<PackageInfoPlugin>;
-String _$deviceInfoHash() => r'737aa403f7f02cb999e488554c1110ae3b2f03d2';
+String _$deviceInfoHash() => r'c16f9af70ea0ce72e120dbf230e92fbf562edccb';
 
 /// Access to [DeviceInfo].
 ///
@@ -1555,6 +1593,8 @@ final deviceInfoProvider = AutoDisposeProvider<DeviceInfoPlugin>.internal(
   allTransitiveDependencies: null,
 );
 
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
 typedef DeviceInfoRef = AutoDisposeProviderRef<DeviceInfoPlugin>;
 // ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/patapata_riverpod/pubspec.yaml
+++ b/packages/patapata_riverpod/pubspec.yaml
@@ -6,21 +6,21 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_riverpo
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
-  flutter_riverpod: ^2.5.1
+  flutter_riverpod: ^2.6.1
   patapata_core: ^1.1.0
-  riverpod_annotation: ^2.3.5
+  riverpod_annotation: ^2.6.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.2
-  riverpod_generator: ^2.4.0
+  riverpod_generator: ^2.6.1
   build_runner: ^2.4.9
   custom_lint: ^0.6.4
   riverpod_lint: ^2.3.10

--- a/packages/patapata_sentry/pubspec.yaml
+++ b/packages/patapata_sentry/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/gree/patapata/tree/main/packages/patapata_sentry
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,26 +13,26 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   charcode:
     dependency: transitive
     description:
@@ -57,14 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.1"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   conventional_commit:
     dependency: transitive
     description:
@@ -77,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   glob:
     dependency: transitive
     description:
@@ -93,26 +101,34 @@ packages:
     dependency: transitive
     description:
       name: graphs
-      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "76d306a1c3afb33fe82e2bbacad62a61f409b5634c915fceb0d799de1a913360"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.1"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -125,34 +141,34 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.9.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.17"
   melos:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: a0cb264096a315e4acdb66ae75ee594a76c97fe15ce9ae469f6c58c6c4b2be87
+      sha256: a62abfa8c7826cec927f8585572bb9adf591be152150494d879ca2c75118809d
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.0"
+    version: "6.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.16.0"
   mustache_template:
     dependency: transitive
     description:
@@ -165,18 +181,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.1"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.6"
   pool:
     dependency: transitive
     description:
@@ -229,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: quiver
-      sha256: b1c1ac5ce6688d77f65f3375a9abb9319b3cb32486bdc7a1e0fdf004d7ba4e47
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   source_span:
     dependency: transitive
     description:
@@ -245,10 +261,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -261,10 +277,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "0bd04f5bb74fcd6ff0606a888a30e917af9bd52820b178eaa464beb11dca84b6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.0"
   term_glyph:
     dependency: transitive
     description:
@@ -277,18 +293,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   uri:
     dependency: transitive
     description:
@@ -297,6 +313,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:
@@ -309,9 +333,9 @@ packages:
     dependency: transitive
     description:
       name: yaml_edit
-      sha256: "1579d4a0340a83cf9e4d580ea51a16329c916973bffd5bd4b45e911b25d46bfd"
+      sha256: e9c1a3543d2da0db3e90270dbb1e4eebc985ee5e3ffe468d83224472b2194a5f
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.1"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.5.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,4 +3,4 @@ name: patapata_workspace
 environment:
   sdk: ">=2.18.0 <4.0.0"
 dev_dependencies:
-  melos: ^5.3.0
+  melos: ^6.2.0


### PR DESCRIPTION
<!--- 
Before submitting a PR, please check the following:
- [ ]  Have you created an issue?
- [ ]  Have you verified that the code changes for this PR pass Patapata's test suite?
- [ ]  Have you reviewed Patapata's licensing?
--->

# Issue Number
fixes https://github.com/gree/patapata/issues/19

# Summary
- Flutter 3.24.4 Support
- Update `patapata_riverpod` dependencies
- The minimum required version of Flutter is now 3.24.0 or higher.