### PR TITLE
Feature/localization

### DIFF
--- a/packages/patapata_core/bin/bootstrap.dart
+++ b/packages/patapata_core/bin/bootstrap.dart
@@ -652,6 +652,7 @@ abstract base class AppException extends PatapataException {
     super.fix,
     super.logLevel,
     super.userLogLevel,
+    super.overridableLocalization,
   });
 
   @override

--- a/packages/patapata_core/lib/src/exception.dart
+++ b/packages/patapata_core/lib/src/exception.dart
@@ -74,6 +74,7 @@ abstract class PatapataCoreException extends PatapataException {
     super.fix,
     super.logLevel,
     super.userLogLevel,
+    super.overridableLocalization,
   }) : _exceptionCode = code;
 
   @override

--- a/packages/patapata_core/lib/src/widgets/standard_page.dart
+++ b/packages/patapata_core/lib/src/widgets/standard_page.dart
@@ -844,6 +844,12 @@ abstract class StandardPageWithResult<T extends Object?, E extends Object?>
   @protected
   AnalyticsEvent? get analyticsSingletonEvent => null;
 
+  /// Localization key for the page.
+  ///
+  /// Used to localize with [pl] or `context.pl`.
+  /// Override this property if you want to localize.
+  String get localizationKey => '';
+
   @override
   @mustCallSuper
   void initState() {
@@ -997,6 +1003,23 @@ abstract class StandardPageWithResult<T extends Object?, E extends Object?>
         );
       }
     }
+  }
+
+  /// {@template patapata_widgets.StandardPageWithResult.pl}
+  /// Calls [l] with the specified [localizationKey].
+  ///
+  /// For example, if [localizationKey] is `pages.home` and [key] is `title`, it is localized as `pages.home.title`.
+  /// An assertion error occurs if [localizationKey] is not set.
+  /// {@endtemplate}
+  @protected
+  String pl(
+    String key, [
+    Map<String, Object>? namedParameters,
+  ]) {
+    assert(localizationKey.isNotEmpty,
+        'localizationKey is not set. Please override localizationKey.');
+
+    return l(context, '$localizationKey.$key', namedParameters);
   }
 
   @override
@@ -2035,6 +2058,27 @@ class StandardRouterDelegate extends RouterDelegate<StandardRouteData>
     }
 
     return tFactory;
+  }
+}
+
+/// An extension class that adds StandardPage functionality to [BuildContext].
+extension StandardPageContext on BuildContext {
+  /// {@macro patapata_widgets.StandardPageWithResult.pl}
+  ///
+  /// Throws an exception if [StandardPageWithResult] does not exist in the widget tree of the context.
+  String pl(
+    String key, [
+    Map<String, Object>? namedParameters,
+  ]) {
+    if (this is StatefulElement) {
+      final tElement = (this as StatefulElement);
+      if (tElement.state is StandardPageWithResult) {
+        final tState = tElement.state as StandardPageWithResult;
+        return tState.pl(key, namedParameters);
+      }
+    }
+
+    return Provider.of<StandardPageWithResult>(this).pl(key, namedParameters);
   }
 }
 

--- a/packages/patapata_core/test/standard_app_widget_test.dart
+++ b/packages/patapata_core/test/standard_app_widget_test.dart
@@ -2976,4 +2976,36 @@ void main() {
 
     tApp.dispose();
   });
+
+  testWidgets('Test of localizationKey. context.pl works correctly.',
+      (widgetTester) async {
+    final App tApp = createApp(
+      appWidget: StandardMaterialApp(
+        onGenerateTitle: (context) => 'Test Title',
+        pages: [
+          StandardPageFactory<TestPageLocalizationKey, void>(
+            create: (data) => TestPageLocalizationKey(),
+          ),
+        ],
+      ),
+    );
+
+    await tApp.run();
+
+    await tApp.runProcess(() async {
+      await widgetTester.pumpAndSettle();
+
+      final tContext = StandardMaterialApp.globalNavigatorContext!;
+
+      expect(find.text(l(tContext, 'test.pl.title')), findsOneWidget);
+      expect(find.text(l(tContext, 'test.pl.message', {'param': 'a'})),
+          findsOneWidget);
+      expect(find.text(l(tContext, 'test.pl.message', {'param': 'b'})),
+          findsOneWidget);
+      expect(find.text(l(tContext, 'test.pl.message', {'param': 'c'})),
+          findsOneWidget);
+    });
+
+    tApp.dispose();
+  });
 }

--- a/packages/patapata_core/test/utils/patapata_core_test_utils.dart
+++ b/packages/patapata_core/test/utils/patapata_core_test_utils.dart
@@ -70,6 +70,9 @@ notification:
   title: NotificationPage
 test:
   title: TestMessage:{param}
+  pl:
+    title: LocalizationTest
+    message: LocalizationTestMessage:{param}
 errors:
   test:
     '000':
@@ -90,6 +93,9 @@ notification:
   title: 通知
 test:
   title: テストメッセージ:{param}
+  pl:
+    title: ローカライズテスト
+    message: ローカライズテストメッセージ:{param}
 errors:
   test:
     '000':

--- a/packages/patapata_core/test/utils/patapata_core_test_utils.dart
+++ b/packages/patapata_core/test/utils/patapata_core_test_utils.dart
@@ -73,6 +73,12 @@ test:
   pl:
     title: LocalizationTest
     message: LocalizationTestMessage:{param}
+    errors:
+      pl:
+        '000':
+          title: PlPageErrorTitle:{prefix}{data}
+          message: PlPageErrorMessage:{prefix}{data}
+          fix: PlPageErrorFix:{prefix}{data}
 errors:
   test:
     '000':
@@ -84,6 +90,15 @@ errors:
         title: ErrorPageTitle
         message: ErrorPageMessage
         fix: ErrorPageFix
+  pl:
+    '000':
+      title: PlErrorTitle:{prefix}{data}
+      message: PlErrorMessage:{prefix}{data}
+      fix: PlErrorFix:{prefix}{data}
+    '111':
+      title: PlErrorTitle2:{prefix}{data}
+      message: PlErrorMessage2:{prefix}{data}
+      fix: PlErrorFix2:{prefix}{data}
 
 ''',
       'l10n/ja.yaml': '''
@@ -96,6 +111,12 @@ test:
   pl:
     title: ローカライズテスト
     message: ローカライズテストメッセージ:{param}
+    errors:
+      pl:
+        '000':
+          title: Plページエラー:{prefix}{data}
+          message: Plページメッセージ:{prefix}{data}
+          fix: Plページ修復:{prefix}{data}
 errors:
   test:
     '000':
@@ -107,6 +128,15 @@ errors:
         title: エラーページ:タイトル
         message: エラーページ:メッセージ
         fix: エラーページ:修復
+  pl:
+    '000':
+      title: Plエラー:{prefix}{data}
+      message: Plメッセージ:{prefix}{data}
+      fix: Pl修復:{prefix}{data}
+    '111':
+      title: Plエラー2:{prefix}{data}
+      message: Plメッセージ2:{prefix}{data}
+      fix: Pl修復2:{prefix}{data}
 ''',
       'l10n2/en.yaml': '''
 home:

--- a/packages/patapata_core/test/utils/standard_app_widget_test_data.dart
+++ b/packages/patapata_core/test/utils/standard_app_widget_test_data.dart
@@ -543,6 +543,43 @@ class TestPageH extends StandardPage<TestPageData> {
   }
 }
 
+class TestPageLocalizationKey extends StandardPage<void> {
+  @override
+  String get localizationKey => 'test.pl';
+
+  String testMessage = '';
+
+  @override
+  Widget build(BuildContext context) {
+    testMessage = context.pl('message', {'param': 'a'});
+    return super.build(context);
+  }
+
+  @override
+  Widget buildPage(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(context.pl('title')),
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            Center(
+              child: Text(testMessage),
+            ),
+            Center(
+              child: Text(context.pl('message', {'param': 'b'})),
+            ),
+            Builder(builder: (context) {
+              return Text(context.pl('message', {'param': 'c'}));
+            })
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class TestPageRemoveRoute extends StandardPage<void> {
   @override
   Widget buildPage(BuildContext context) {

--- a/packages/patapata_example_app/l10n/en.yaml
+++ b/packages/patapata_example_app/l10n/en.yaml
@@ -43,6 +43,17 @@ pages:
     example: Normal Error
     network: Network Error({prefix})
     maintenance: Maintenance Error
+    specific: Page Specific Error
+  error_specific:
+    title: Page Specific Error
+    body: It raises the same exception as the “Normal Error” on the previous page, but the message displayed is different.
+    example: Test
+    back: Back
+    errors:
+      app:
+        '000':
+          title: Page Specific Error ({prefix}000)
+          message: Specific Error.
   maintenance:
     title: Server Maintenance
     message: Currently unavailable due to server maintenance. Returning to the Top Page.

--- a/packages/patapata_example_app/l10n/ja.yaml
+++ b/packages/patapata_example_app/l10n/ja.yaml
@@ -43,6 +43,17 @@ pages:
     example: 通常のエラー
     network: ネットワークエラー({prefix})
     maintenance: メンテナンス中エラー
+    specific: ページ特有のエラー
+  error_specific:
+    title: ページ特有のエラー
+    body: 前ページの「通常のエラー」と同じ例外を発生させますが、表示されるメッセージが異なります。
+    example: テスト
+    back: 戻る
+    errors:
+      app:
+        '000':
+          title: ページ特有のエラー（{prefix}000）
+          message: ページ特有のエラーが発生しました。
   maintenance:
     title: サーバーメンテナンス
     message: 現在サーバーメンテンス中のため利用できません。トップページに戻ります。

--- a/packages/patapata_example_app/lib/exceptions.dart
+++ b/packages/patapata_example_app/lib/exceptions.dart
@@ -23,6 +23,7 @@ base class ExampleException extends AppException {
     super.fix,
     super.logLevel,
     super.userLogLevel,
+    super.overridableLocalization,
   });
 
   @override

--- a/packages/patapata_example_app/lib/main.dart
+++ b/packages/patapata_example_app/lib/main.dart
@@ -206,6 +206,9 @@ Widget _createAppWidget(BuildContext context, App<Environment> app) {
           },
           linkGenerator: (pageData) => '/error',
         ),
+        StandardPageFactory<ErrorPageSpecificPage, void>(
+          create: (_) => ErrorPageSpecificPage(),
+        ),
         // Material Tab and pages.
         // TitlePage and TitleDetailsPage are pages related to the tabs on the HomePage.
         // The parent of the tabs in Home is the HomePage,

--- a/packages/patapata_example_app/lib/src/errors.dart
+++ b/packages/patapata_example_app/lib/src/errors.dart
@@ -20,6 +20,7 @@ abstract base class AppException extends PatapataException {
     super.fix,
     super.logLevel,
     super.userLogLevel,
+    super.overridableLocalization,
   });
 
   @override

--- a/packages/patapata_example_app/lib/src/pages/agreement_page.dart
+++ b/packages/patapata_example_app/lib/src/pages/agreement_page.dart
@@ -11,26 +11,27 @@ import 'package:patapata_core/patapata_widgets.dart';
 /// It appears after the splash screen. If the user does not agree, they will be taken back to the splash screen again.
 class AgreementPage extends StandardPage<StartupPageCompleter> {
   @override
+  String localizationKey = 'pages.agreement';
+
+  @override
   Widget buildPage(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(l(context, 'pages.agreement.title')),
+        title: Text(context.pl('title')),
       ),
       body: Column(
         children: [
           Center(
-            child: Text(
-              l(context, 'pages.agreement.body'),
-            ),
+            child: Text(context.pl('body')),
           ),
           TextButton(
-            child: Text(l(context, 'pages.agreement.yes')),
+            child: Text(context.pl('yes')),
             onPressed: () {
               pageData(null);
             },
           ),
           TextButton(
-            child: Text(l(context, 'pages.agreement.no')),
+            child: Text(context.pl('no')),
             onPressed: () {
               // Calling the sequence processing again will resume the sequence from the beginning.
               getApp().startupSequence?.resetMachine();

--- a/packages/patapata_example_app/lib/src/pages/config_page.dart
+++ b/packages/patapata_example_app/lib/src/pages/config_page.dart
@@ -12,26 +12,27 @@ import 'package:provider/provider.dart';
 /// Here, values are being saved, modified, and retrieved for a LocalConfig with the key name counter.
 class ConfigPage extends StandardPage<void> {
   @override
+  String localizationKey = 'pages.config';
+
+  @override
   Widget buildPage(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(l(context, 'pages.config.title')),
+        title: Text(context.pl('title')),
       ),
       body: ListView(
         children: [
           Center(
-            child: Text(l(context, 'pages.config.body')),
+            child: Text(context.pl('body')),
           ),
           Center(
             child: Builder(
               builder: (context) {
                 // Retrieve the value of counter from LocalConfig.
-                return Text(
-                  l(context, 'plurals.test1', {
-                    'count': context
-                        .select<LocalConfig, int>((v) => v.getInt('counter'))
-                  }),
-                );
+                return Text(l(context, 'plurals.test1', {
+                  'count': context
+                      .select<LocalConfig, int>((v) => v.getInt('counter'))
+                }));
               },
             ),
           ),
@@ -41,14 +42,14 @@ class ConfigPage extends StandardPage<void> {
               getApp().localConfig.setInt(
                   'counter', getApp().localConfig.getInt('counter') + 1);
             },
-            child: Text(l(context, 'pages.config.increment')),
+            child: Text(context.pl('increment')),
           ),
           TextButton(
             onPressed: () {
               // Delete the value stored in LocalConfig.
               getApp().localConfig.reset('counter');
             },
-            child: Text(l(context, 'pages.config.clear')),
+            child: Text(context.pl('clear')),
           ),
         ],
       ),

--- a/packages/patapata_example_app/lib/src/pages/device_and_package_info_page.dart
+++ b/packages/patapata_example_app/lib/src/pages/device_and_package_info_page.dart
@@ -11,6 +11,9 @@ import 'package:patapata_core/patapata_widgets.dart';
 /// This is a page demonstrating how to use DeviceInfo and PackageInfo.
 class DeviceAndPackageInfoPage extends StandardPage<void> {
   @override
+  String localizationKey = 'pages.device_and_package_info';
+
+  @override
   Widget buildPage(BuildContext context) {
     // Get the device model name.
     // If the platform is Web, you can retrieve the browser name.
@@ -31,14 +34,12 @@ class DeviceAndPackageInfoPage extends StandardPage<void> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(l(context, 'pages.device_and_package_info.title')),
+        title: Text(context.pl('title')),
       ),
       body: ListView(
         children: [
           Center(
-            child: Text(
-              l(context, 'pages.device_and_package_info.body'),
-            ),
+            child: Text(context.pl('body')),
           ),
           Table(
             border: TableBorder.all(),
@@ -47,8 +48,7 @@ class DeviceAndPackageInfoPage extends StandardPage<void> {
                 children: [
                   TableCell(
                     child: Center(
-                      child: Text(
-                          l(context, 'pages.device_and_package_info.model')),
+                      child: Text(context.pl('model')),
                     ),
                   ),
                   TableCell(
@@ -60,8 +60,7 @@ class DeviceAndPackageInfoPage extends StandardPage<void> {
                 children: [
                   TableCell(
                     child: Center(
-                      child: Text(
-                          l(context, 'pages.device_and_package_info.app_name')),
+                      child: Text(context.pl('app_name')),
                     ),
                   ),
                   TableCell(
@@ -74,8 +73,8 @@ class DeviceAndPackageInfoPage extends StandardPage<void> {
                 children: [
                   TableCell(
                     child: Center(
-                        child: Text(l(context,
-                            'pages.device_and_package_info.build_number'))),
+                      child: Text(context.pl('build_number')),
+                    ),
                   ),
                   TableCell(
                     // Get the build number from PackageInfo.
@@ -88,8 +87,8 @@ class DeviceAndPackageInfoPage extends StandardPage<void> {
                 children: [
                   TableCell(
                     child: Center(
-                        child: Text(l(context,
-                            'pages.device_and_package_info.build_signature'))),
+                      child: Text(context.pl('build_signature')),
+                    ),
                   ),
                   TableCell(
                     // Get the build signature from PackageInfo.
@@ -102,8 +101,8 @@ class DeviceAndPackageInfoPage extends StandardPage<void> {
                 children: [
                   TableCell(
                     child: Center(
-                        child: Text(l(context,
-                            'pages.device_and_package_info.package_name'))),
+                      child: Text(context.pl('package_name')),
+                    ),
                   ),
                   TableCell(
                     // Get the package name from PackageInfo.
@@ -116,8 +115,8 @@ class DeviceAndPackageInfoPage extends StandardPage<void> {
                 children: [
                   TableCell(
                     child: Center(
-                        child: Text(l(
-                            context, 'pages.device_and_package_info.version'))),
+                      child: Text(context.pl('version')),
+                    ),
                   ),
                   // Get the app version from PackageInfo.
                   TableCell(

--- a/packages/patapata_example_app/lib/src/pages/error_page.dart
+++ b/packages/patapata_example_app/lib/src/pages/error_page.dart
@@ -80,10 +80,13 @@ class UnknownExceptionPage extends StandardPage<ReportRecord> {
 /// ErrorSelectPage is a page that allows you to select the type of error to display.
 class ErrorSelectPage extends StandardPage<void> {
   @override
+  String localizationKey = 'pages.error';
+
+  @override
   Widget buildPage(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(l(context, 'pages.error.title')),
+        title: Text(context.pl('title')),
       ),
       body: ListView(
         children: [
@@ -97,7 +100,7 @@ class ErrorSelectPage extends StandardPage<void> {
                 logger.severe(e.toString(), e);
               }
             },
-            child: Text(l(context, 'pages.error.example')),
+            child: Text(context.pl('example')),
           ),
           // Throw a network exception named ExampleNetworkException, defined in the sample app, and log it.
           // Specify the network status code in the statusCode argument of ExampleNetworkException.
@@ -110,7 +113,7 @@ class ErrorSelectPage extends StandardPage<void> {
                 logger.severe(e.toString(), e);
               }
             },
-            child: Text(l(context, 'pages.error.network', {'prefix': '404'})),
+            child: Text(context.pl('network', {'prefix': '404'})),
           ),
           TextButton(
             onPressed: () {
@@ -121,7 +124,7 @@ class ErrorSelectPage extends StandardPage<void> {
                 logger.severe(e.toString(), e);
               }
             },
-            child: Text(l(context, 'pages.error.network', {'prefix': '500'})),
+            child: Text(context.pl('network', {'prefix': '500'})),
           ),
           // Throw ExampleMaintenanceException, transition to the maintenance page, and navigate to ErrorSelectPage.
           TextButton(
@@ -136,7 +139,7 @@ class ErrorSelectPage extends StandardPage<void> {
                 logger.severe(e.toString(), e);
               }
             },
-            child: Text(l(context, 'pages.error.maintenance')),
+            child: Text(context.pl('maintenance')),
           ),
         ],
       ),

--- a/packages/patapata_example_app/lib/src/pages/error_page.dart
+++ b/packages/patapata_example_app/lib/src/pages/error_page.dart
@@ -141,6 +141,80 @@ class ErrorSelectPage extends StandardPage<void> {
             },
             child: Text(context.pl('maintenance')),
           ),
+          Padding(
+            padding: const EdgeInsets.all(25.0),
+            child: Center(
+              child: FilledButton(
+                onPressed: () {
+                  context.go<ErrorPageSpecificPage, void>(null);
+                },
+                child: Text(context.pl('specific')),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ErrorPageSpecificPage extends StandardPage<void> {
+  @override
+  String localizationKey = 'pages.error_specific';
+
+  @override
+  Widget buildPage(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(context.pl('title')),
+      ),
+      body: ListView(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(25.0),
+            child: Center(
+              child: Text(
+                context.pl('body'),
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: () {
+              try {
+                throw ExampleException();
+              } on PatapataException catch (e) {
+                e.showDialog(context);
+                logger.severe(e.toString(), e);
+              }
+            },
+            child: Text(context.pl('example')),
+          ),
+          TextButton(
+            onPressed: () {
+              try {
+                throw ExampleException(
+                  overridableLocalization: false,
+                );
+              } on PatapataException catch (e) {
+                e.showDialog(context);
+                logger.severe(e.toString(), e);
+              }
+            },
+            child: Text(
+                '${context.pl('example')} (overridableLocalization: false)'),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(25.0),
+            child: Center(
+              child: FilledButton(
+                onPressed: () {
+                  context.go<ErrorSelectPage, void>(
+                      null, StandardPageNavigationMode.removeAbove);
+                },
+                child: Text(context.pl('back')),
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/packages/patapata_example_app/lib/src/pages/home_page.dart
+++ b/packages/patapata_example_app/lib/src/pages/home_page.dart
@@ -21,10 +21,13 @@ class HomePage extends StandardPage<void> {
 /// [TitlePage] is a StandardPage representing the [HomePage] tab in an application with a tabbed footer.
 class TitlePage extends StandardPage<void> {
   @override
+  String localizationKey = 'pages.tab.home';
+
+  @override
   Widget buildPage(BuildContext context) {
     return AppTab(
       appBar: AppBar(
-        title: Text(l(context, 'pages.tab.home.title')),
+        title: Text(context.pl('title')),
         automaticallyImplyLeading: false,
         leading: const StandardPageBackButton(),
       ),
@@ -33,7 +36,7 @@ class TitlePage extends StandardPage<void> {
           Center(
             child: Builder(
               builder: (context) {
-                return Text(l(context, 'pages.tab.home.body'));
+                return Text(context.pl('body'));
               },
             ),
           ),
@@ -52,10 +55,13 @@ class TitlePage extends StandardPage<void> {
 /// [TitleDetailsPage] is a StandardPage that serves as a child of [TitlePage] in the [HomePage] tab of an application with a tabbed footer.
 class TitleDetailsPage extends StandardPage<void> {
   @override
+  String localizationKey = 'pages.tab.title_details';
+
+  @override
   Widget buildPage(BuildContext context) {
     return AppTab(
       appBar: AppBar(
-        title: Text(l(context, 'pages.tab.title_details.title')),
+        title: Text(context.pl('title')),
         automaticallyImplyLeading: false,
         leading: const StandardPageBackButton(),
       ),
@@ -64,9 +70,7 @@ class TitleDetailsPage extends StandardPage<void> {
           Center(
             child: Builder(
               builder: (context) {
-                return Text(
-                  l(context, 'pages.tab.title_details.body'),
-                );
+                return Text(context.pl('body'));
               },
             ),
           ),

--- a/packages/patapata_example_app/lib/src/pages/my_page.dart
+++ b/packages/patapata_example_app/lib/src/pages/my_page.dart
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 import 'package:flutter/material.dart';
-import 'package:patapata_core/patapata_core.dart';
 import 'package:patapata_core/patapata_widgets.dart';
 import 'package:patapata_example_app/src/widgets/app_tab.dart';
 
@@ -21,10 +20,13 @@ class MyPage extends StandardPage<void> {
 /// [MyPage] is a StandardPage representing the [MyFavoritePage] tab in an application with a tabbed footer.
 class MyFavoritePage extends StandardPage<void> {
   @override
+  String localizationKey = 'pages.tab.my_page';
+
+  @override
   Widget buildPage(BuildContext context) {
     return AppTab(
       appBar: AppBar(
-        title: Text(l(context, 'pages.tab.my_page.title')),
+        title: Text(context.pl('title')),
         automaticallyImplyLeading: false,
         leading: const StandardPageBackButton(),
       ),
@@ -33,9 +35,7 @@ class MyFavoritePage extends StandardPage<void> {
           Center(
             child: Builder(
               builder: (context) {
-                return Text(
-                  l(context, 'pages.tab.my_page.body'),
-                );
+                return Text(context.pl('body'));
               },
             ),
           ),

--- a/packages/patapata_example_app/lib/src/pages/screen_layout_example_page.dart
+++ b/packages/patapata_example_app/lib/src/pages/screen_layout_example_page.dart
@@ -4,10 +4,12 @@
 // LICENSE file in the root directory of this source tree.
 
 import 'package:flutter/material.dart';
-import 'package:patapata_core/patapata_core.dart';
 import 'package:patapata_core/patapata_widgets.dart';
 
 class ScreenLayoutExamplePage extends StandardPage<void> {
+  @override
+  String localizationKey = 'pages.screen_layout_example';
+
   final _breakpoints = const ScreenLayoutBreakpoints(
     portraitStandardBreakpoint: 375.0,
     portraitConstrainedWidth: double.infinity,
@@ -17,31 +19,26 @@ class ScreenLayoutExamplePage extends StandardPage<void> {
   );
 
   String createSampleDescription(double width) {
-    String tDescription =
-        l(context, 'pages.screen_layout_example.base_description_before');
+    String tDescription = context.pl('base_description_before');
 
     if (width == 375) {
-      tDescription += l(
-        context,
-        'pages.screen_layout_example.description_case_equal',
+      tDescription += context.pl(
+        'description_case_equal',
         {'width': widget},
       );
     } else if (width > 375) {
-      tDescription += l(
-        context,
-        'pages.screen_layout_example.description_case_over',
+      tDescription += context.pl(
+        'description_case_over',
         {'width': widget},
       );
     } else {
-      tDescription += l(
-        context,
-        'pages.screen_layout_example.description_case_other',
+      tDescription += context.pl(
+        'description_case_other',
         {'width': widget},
       );
     }
 
-    tDescription +=
-        l(context, 'pages.screen_layout_example.base_description_before');
+    tDescription += context.pl('base_description_before');
 
     return tDescription;
   }
@@ -83,13 +80,13 @@ class ScreenLayoutExamplePage extends StandardPage<void> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(l(context, 'pages.screen_layout_example.title')),
+        title: Text(context.pl('title')),
       ),
       body: Center(
         child: ListView(
           children: [
             Center(
-              child: Text(l(context, 'pages.screen_layout_example.body')),
+              child: Text(context.pl('body')),
             ),
             Padding(
               padding: const EdgeInsets.all(8),
@@ -99,7 +96,7 @@ class ScreenLayoutExamplePage extends StandardPage<void> {
             ),
             Center(
               child: Text(
-                l(context, 'pages.screen_layout_example.sample_a'),
+                context.pl('sample_a'),
                 style: const TextStyle(fontSize: 24),
               ),
             ),
@@ -107,7 +104,7 @@ class ScreenLayoutExamplePage extends StandardPage<void> {
             const SizedBox(height: 32),
             Center(
               child: Text(
-                l(context, 'pages.screen_layout_example.sample_b'),
+                context.pl('sample_b'),
                 style: const TextStyle(fontSize: 24),
               ),
             ),
@@ -118,8 +115,7 @@ class ScreenLayoutExamplePage extends StandardPage<void> {
             const SizedBox(height: 32),
             Padding(
               padding: const EdgeInsets.all(8),
-              child:
-                  Text(l(context, 'pages.screen_layout_example.description')),
+              child: Text(context.pl('description')),
             ),
             Center(
               child: ScreenLayout(
@@ -132,7 +128,7 @@ class ScreenLayoutExamplePage extends StandardPage<void> {
             Padding(
               padding: const EdgeInsets.all(8),
               child: Text(
-                l(context, 'pages.screen_layout_example.description_example'),
+                context.pl('description_example'),
               ),
             ),
           ],

--- a/packages/patapata_example_app/lib/src/pages/standard_page_example_page.dart
+++ b/packages/patapata_example_app/lib/src/pages/standard_page_example_page.dart
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 import 'package:flutter/material.dart';
-import 'package:patapata_core/patapata_core.dart';
 import 'package:patapata_core/patapata_widgets.dart';
 import 'package:provider/provider.dart';
 
@@ -13,29 +12,30 @@ import '../../page_data.dart';
 /// The simplest example of StandardPage without holding any PageData.
 class StandardPageExamplePage extends StandardPage<void> {
   @override
+  String localizationKey = 'pages.standard_page';
+
+  @override
   Widget buildPage(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(l(context, 'pages.standard_page.title')),
+        title: Text(context.pl('title')),
       ),
       body: ListView(
         children: [
           Center(
-            child: Text(l(context, 'pages.standard_page.body')),
+            child: Text(context.pl('body')),
           ),
           TextButton(
             onPressed: () {
               context.go<HasDataPage, PageData>(PageData());
             },
-            child: Text(
-                l(context, 'pages.standard_page.go_to_next_standard_page')),
+            child: Text(context.pl('go_to_next_standard_page')),
           ),
           TextButton(
             onPressed: () {
               context.go<CustomStandardPage, void>(null);
             },
-            child: Text(
-                l(context, 'pages.standard_page.go_to_custom_standard_page')),
+            child: Text(context.pl('go_to_custom_standard_page')),
           ),
           TextButton(
             onPressed: () {
@@ -43,7 +43,7 @@ class StandardPageExamplePage extends StandardPage<void> {
                 ChangeListenableNumber(),
               );
             },
-            child: Text(l(context, 'pages.standard_page.go_to_page_data')),
+            child: Text(context.pl('go_to_page_data')),
           ),
         ],
       ),
@@ -56,17 +56,19 @@ class StandardPageExamplePage extends StandardPage<void> {
 /// To access members of this PageData, you can use syntax like pageData.hello.
 class HasDataPage extends StandardPage<PageData> {
   @override
+  String localizationKey = 'pages.standard_page';
+
+  @override
   Widget buildPage(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(l(context, 'pages.standard_page.title')),
+        title: Text(context.pl('title')),
       ),
       body: ListView(
         children: [
           Center(
-            child: Text(l(
-                context,
-                'pages.standard_page.page_data_value',
+            child: Text(context.pl(
+                'page_data_value',
                 // You can access members of PageData like this.
                 {'prefix': pageData.hello})),
           ),
@@ -76,7 +78,7 @@ class HasDataPage extends StandardPage<PageData> {
               pageData = PageData(hello: 'change hi!');
               setState(() {});
             },
-            child: Text(l(context, 'pages.standard_page.change_page_data')),
+            child: Text(context.pl('change_page_data')),
           ),
         ],
       ),
@@ -87,15 +89,18 @@ class HasDataPage extends StandardPage<PageData> {
 /// A page to display a customized StandardPage.
 class CustomStandardPage extends StandardPage<void> {
   @override
+  String localizationKey = 'pages.standard_page';
+
+  @override
   Widget buildPage(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(l(context, 'pages.standard_page.title')),
+        title: Text(context.pl('title')),
       ),
       body: ListView(
         children: [
           Center(
-            child: Text(l(context, 'pages.standard_page.body')),
+            child: Text(context.pl('body')),
           ),
         ],
       ),
@@ -106,19 +111,22 @@ class CustomStandardPage extends StandardPage<void> {
 /// Example of manipulating or modifying values in PageData and retrieving values through a Provider in StandardPage.
 class ChangeListenablePage extends StandardPage<BaseListenable> {
   @override
+  String localizationKey = 'pages.standard_page';
+
+  @override
   Widget buildPage(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(l(context, 'pages.standard_page.title')),
+        title: Text(context.pl('title')),
       ),
       body: ListView(
         children: [
           Center(
-            child: Text(l(context, 'pages.standard_page.body')),
+            child: Text(context.pl('body')),
           ),
           Center(
             // Observe changes to the value of CountData set in MultiProvider within routableBuilder.
-            child: Text(l(context, 'pages.standard_page.page_data_count',
+            child: Text(context.pl('page_data_count',
                 {'prefix': context.watch<CountData>().count})),
           ),
           TextButton(
@@ -131,21 +139,16 @@ class ChangeListenablePage extends StandardPage<BaseListenable> {
               }
               setState(() {});
             },
-            child:
-                Text(l(context, 'pages.standard_page.change_page_data_type')),
+            child: Text(context.pl('change_page_data_type')),
           ),
           if (pageData is ChangeListenableBool)
             Center(
-              child: Text(l(
-                  context,
-                  'pages.standard_page.change_page_data_result',
+              child: Text(context.pl('change_page_data_result',
                   {'prefix': context.watch<ChangeListenableBool>().data})),
             ),
           if (pageData is ChangeListenableNumber)
             Center(
-              child: Text(l(
-                  context,
-                  'pages.standard_page.change_page_data_result',
+              child: Text(context.pl('change_page_data_result',
                   {'prefix': context.watch<ChangeListenableNumber>().data})),
             ),
         ],

--- a/packages/patapata_example_app/lib/src/pages/top_page.dart
+++ b/packages/patapata_example_app/lib/src/pages/top_page.dart
@@ -4,7 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 
 import 'package:flutter/material.dart';
-import 'package:patapata_core/patapata_core.dart';
 import 'package:patapata_core/patapata_widgets.dart';
 import 'package:patapata_example_app/src/pages/device_and_package_info_page.dart';
 import 'package:patapata_example_app/src/pages/error_page.dart';
@@ -18,51 +17,54 @@ import 'home_page.dart';
 /// You can navigate to a sample screen demonstrating the features of Patapata from this pages.
 class TopPage extends StandardPage<void> {
   @override
+  String localizationKey = 'pages.top';
+
+  @override
   Widget buildPage(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(l(context, 'pages.top.title')),
+        title: Text(context.pl('title')),
       ),
       body: ListView(
         children: [
           Center(
-            child: Text(l(context, 'pages.top.body')),
+            child: Text(context.pl('body')),
           ),
           TextButton(
             onPressed: () {
               context.go<ConfigPage, void>(null);
             },
-            child: Text(l(context, 'pages.top.go_to_config')),
+            child: Text(context.pl('go_to_config')),
           ),
           TextButton(
             onPressed: () {
               context.go<ScreenLayoutExamplePage, void>(null);
             },
-            child: Text(l(context, 'pages.top.go_to_screen_layout')),
+            child: Text(context.pl('go_to_screen_layout')),
           ),
           TextButton(
             onPressed: () {
               context.go<StandardPageExamplePage, void>(null);
             },
-            child: Text(l(context, 'pages.top.go_to_standard_page')),
+            child: Text(context.pl('go_to_standard_page')),
           ),
           TextButton(
             onPressed: () {
               context.go<DeviceAndPackageInfoPage, void>(null);
             },
-            child: Text(l(context, 'pages.top.go_to_device_and_pakage_info')),
+            child: Text(context.pl('go_to_device_and_pakage_info')),
           ),
           TextButton(
             onPressed: () {
               context.go<ErrorSelectPage, void>(null);
             },
-            child: Text(l(context, 'pages.top.go_to_error')),
+            child: Text(context.pl('go_to_error')),
           ),
           TextButton(
             onPressed: () {
               context.go<HomePage, void>(null);
             },
-            child: Text(l(context, 'pages.top.go_to_tab')),
+            child: Text(context.pl('go_to_tab')),
           ),
         ],
       ),


### PR DESCRIPTION
# Issue Number
fixes https://github.com/gree/patapata/issues/37

# Summary
- The StandardPage now includes the `StandardPageWithResult.localizationKey` property. This allows for localization by utilizing context.pl with the specified key.
- When creating a `PatapataException` , if the currently displayed page has a [StandardPageWithResult.localizationKey]
 set, the default key can now be overridden using the localizationKey.