### PR TITLE
fix: Build failure due to a dependency error with connectivity_plus.

### DIFF
--- a/packages/patapata_core/lib/src/network.dart
+++ b/packages/patapata_core/lib/src/network.dart
@@ -44,6 +44,17 @@ enum NetworkConnectivity {
   /// There is no separate network interface type for [vpn].
   /// It returns [other] on any device (also simulator).
   vpn,
+
+  /// Satellite: Device is connected via a highly constrained satellite link.
+  ///
+  /// On iOS and macOS, reported when [NWPath.isUltraConstrained] is true.
+  /// Appears alongside [mobile] (e.g. `[mobile, satellite]`).
+  ///
+  /// On Android 15 (API 35) and newer, reported when [TRANSPORT_SATELLITE] capability
+  /// is present.
+  ///
+  /// Not reported on other platforms.
+  satellite,
 }
 
 /// A class representing the current network status of [App].
@@ -155,6 +166,9 @@ class NetworkPlugin extends Plugin with WidgetsBindingObserver {
           ConnectivityResult.ethernet => NetworkConnectivity.ethernet,
           ConnectivityResult.bluetooth => NetworkConnectivity.bluetooth,
           ConnectivityResult.vpn => NetworkConnectivity.vpn,
+          ConnectivityResult.satellite => NetworkConnectivity.satellite,
+          // ignore: unreachable_switch_case
+          _ => NetworkConnectivity.other, // coverage:ignore-line
         },
     ];
 

--- a/packages/patapata_core/test/network_test.dart
+++ b/packages/patapata_core/test/network_test.dart
@@ -93,6 +93,7 @@ void main() {
         [NetworkConnectivity.ethernet],
         [NetworkConnectivity.bluetooth],
         [NetworkConnectivity.vpn],
+        [NetworkConnectivity.satellite],
       ];
 
       tNetwork.init(tApp);
@@ -209,6 +210,23 @@ void main() {
         isTrue,
       );
     });
+
+    test(
+      'Function _onConnectivityChanged NetworkConnectivity.satellite',
+      () async {
+        final NetworkPlugin tNetwork = NetworkPlugin();
+
+        testOnConnectivityChangedValue = [NetworkConnectivity.satellite];
+        await tNetwork.didChangeAppLifecycleState(AppLifecycleState.resumed);
+
+        expect(
+          tNetwork.information.connectivities.contains(
+            NetworkConnectivity.satellite,
+          ),
+          isTrue,
+        );
+      },
+    );
 
     test('Function dispose', () async {
       final App tApp = createApp();


### PR DESCRIPTION
<!--- 
Before submitting a PR, please check the following:
- [ ]  Have you created an issue?
- [ ]  Have you verified that the code changes for this PR pass Patapata's test suite?
- [ ]  Have you reviewed Patapata's licensing?
--->

# Issue Number
fixes https://github.com/gree/patapata/issues/50
<!--- 
- Please specify the Patapata issue number.
- Add the number after the hashtag (#). (For example, please write it as #1)
--->

# Summary
- Added NetworkConnectivity.satellite to align with the enum added in connectivity_plus_platform_interface.
- Added a fallback to treat unexpected ConnectivityResult values as NetworkConnectivity.other.