### PR TITLE
Fix/dependencies error

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       matrix:
         flutterVersion:
-          - '3.38.5'
+          - '3.41.6'
+          - '3.38.0'
           - '3.35.0'
 
     steps:

--- a/packages/patapata_core/pubspec.yaml
+++ b/packages/patapata_core/pubspec.yaml
@@ -45,7 +45,6 @@ dependencies:
   vector_math: ^2.0.0
 
 dev_dependencies:
-  test: ">=1.20.0"
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/packages/patapata_core/test/repository/cache_map_test.dart
+++ b/packages/patapata_core/test/repository/cache_map_test.dart
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:patapata_core/src/repository.dart';
 
 void main() {


### PR DESCRIPTION
`patapata_core` had a direct test dependency that caused a dependency resolution conflict between the Flutter SDK’s `flutter_test` and the analyzer constraint in `patapata_builder`, so this dependency has been removed.

The affected tests do not require the `test` package and can use `flutter_test` instead.

This has been verified with `melos bootstrap` and the affected tests.

Additionally, `Flutter 3.41.6` has been added to the GitHub Actions build matrix to ensure the project can be built with the latest Flutter version available at the time of this PR.